### PR TITLE
fix: point cloud compression

### DIFF
--- a/src/era_5g_relay_network_application/era_5g_relay_network_application/client.py
+++ b/src/era_5g_relay_network_application/era_5g_relay_network_application/client.py
@@ -15,7 +15,7 @@ from rclpy.qos import QoSProfile, QoSReliabilityPolicy, QoSHistoryPolicy
 import numpy as np
 from sys import getsizeof
 
-from sensor_msgs_py.point_cloud2 import read_points, create_cloud_xyz32
+from sensor_msgs_py.point_cloud2 import read_points_numpy, create_cloud_xyz32
 import DracoPy
 
 import rclpy
@@ -115,7 +115,7 @@ def callback_others(data: Any, topic_name=None, topic_type=None, compression: Co
     
         
     if topic_type == "sensor_msgs/msg/PointCloud2" and compression == Compressions.DRACO:
-        np_arr = np.array(list(read_points(data)))[:, :3]  # drop intensity...
+        np_arr = read_points_numpy(data, field_names=["x", "y", "z"], skip_nans=True)  # drop intensity, etc...
 
         before_comp = time.monotonic_ns()
         cpc = DracoPy.encode(np_arr, compression_level=1)

--- a/src/era_5g_relay_network_application/era_5g_relay_network_application/worker_results.py
+++ b/src/era_5g_relay_network_application/era_5g_relay_network_application/worker_results.py
@@ -1,4 +1,3 @@
-import time
 from typing import Any
 
 from rclpy.node import Node
@@ -10,7 +9,7 @@ from lz4.frame import compress
 from era_5g_relay_network_application.data.packets import MessagePacket, PacketType
 
 from sensor_msgs.msg import PointCloud2
-from sensor_msgs_py.point_cloud2 import read_points
+from sensor_msgs_py.point_cloud2 import read_points_numpy
 import DracoPy
 import numpy as np
 from era_5g_relay_network_application.utils import Compressions
@@ -54,7 +53,7 @@ class WorkerResults:
         )
 
         if isinstance(data, PointCloud2):
-            np_arr = np.array(list(read_points(data)))[:, :3]  # drop intensity...
+            np_arr = read_points_numpy(data, field_names=["x", "y", "z"], skip_nans=True)  # drop intensity, etc....
             cpc = DracoPy.encode(np_arr, compression_level=1)
             message.data["data"] = cpc
 


### PR DESCRIPTION
- It worked in Foxy, but not in Humble.
- Use unstructured numpy array. The structured one (which is output from read_points in ROS2 Humble) is not supported by Draco.
- Now it won't work in Foxy.