### PR TITLE
ci: pants.yaml update upload-artifact from v3 to v4

### DIFF
--- a/.github/workflows/pants.yaml
+++ b/.github/workflows/pants.yaml
@@ -52,7 +52,7 @@ jobs:
         pip install pipdeptree
         pipdeptree -w fail
     - name: Upload pants log
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: pants-log
         path: .pants.d/pants.log


### PR DESCRIPTION
Deprecation of upload-artifact v3 results into automatic failure of CI check