### PR TITLE
Fix result_subscribers leak: disconnect discards a different SID than subscribe adds

### DIFF
--- a/era_5g_relay_network_application/server.py
+++ b/era_5g_relay_network_application/server.py
@@ -91,6 +91,9 @@ class RelayServer(NetworkApplicationServer):
         # callback_info needs to be passed to the parent class
         super().__init__(port, self.callbacks_info, *args, command_callback=self.command_callback, host=host, **kwargs)
         self.result_subscribers = LockedSet()  # contains data namespace SIDs of clients that want to receive results
+        # maps engine.io SID -> data namespace SID, so that disconnect_callback
+        # can discard the same identifier that was added on subscribe
+        self._result_subscriber_sids: Dict[str, str] = {}
 
         # collects info about topics that are subscribed to be sent to the relay client
         for topic_out in topics_outgoing.values():
@@ -216,15 +219,26 @@ class RelayServer(NetworkApplicationServer):
             if args:
                 sr = args.get("subscribe_results")
                 if sr:
-                    sid = self.get_sid_of_data(self.get_eio_sid_of_control(sid))
+                    eio_sid = self.get_eio_sid_of_control(sid)
+                    sid = self.get_sid_of_data(eio_sid)
                     self.result_subscribers.add(sid)
+                    self._result_subscriber_sids[eio_sid] = sid
                     # notify all worker subscribers so they send cached messages to the newly connected client
                     self.command_queue.put_nowait((sid, command))
         return True, ""
 
     def disconnect_callback(self, eio_sid):
-        """Removes the client from the list of result subscribers."""
-        self.result_subscribers.discard(eio_sid)
+        """Removes the client from the list of result subscribers.
+
+        The subscribe path stores DATA-namespace SIDs in result_subscribers,
+        while this callback receives the engine.io SID: discarding eio_sid
+        directly never matches, so entries of disconnected clients used to
+        stay in the set forever (the outgoing workers then kept forwarding
+        to dead subscribers, degrading egress throughput monotonically with
+        every client that ever connected)."""
+        data_sid = self._result_subscriber_sids.pop(eio_sid, None)
+        if data_sid is not None:
+            self.result_subscribers.discard(data_sid)
 
 
 def provide_action(


### PR DESCRIPTION
## Summary

The result-subscribers set in the relay server never shrinks: the subscribe path stores the **data-namespace SID** (`get_sid_of_data(get_eio_sid_of_control(sid))`) in `result_subscribers`, while `disconnect_callback` receives the **engine.io SID** and calls `discard(eio_sid)`. The identifiers never match, so every client that ever connected stays in the set forever, and the outgoing workers keep forwarding to (and waiting on) dead subscriber entries.

**Observed impact** (100-run robotics data campaign, `but5gera/ros2_relay_server:1.4.0`): egress throughput degraded monotonically with connection churn — a fresh server forwarded results at ~9 Hz, but after a dozen client reconnects the same stream was down to ~2.5 Hz, and only a server restart (which empties the set) recovered it. A set census confirmed the leak: 13 historical connections, 12 clean disconnects logged, 13 entries still in the set.

As a secondary effect, `discard(eio_sid)` calls the current `LockedSet.discard()`, which delegates to `set.remove()` and raises `KeyError` on the (always-missing) element.

## Fix

Track the `eio_sid -> data_sid` mapping when a client subscribes, and discard **that** identifier on disconnect:

- subscribe: store `self._result_subscriber_sids[eio_sid] = sid` alongside `result_subscribers.add(sid)`;
- disconnect: `pop` the mapping and `discard` the data-namespace SID (only ever called for elements known to be present, so it is also safe with the current `LockedSet.discard` behaviour).

After the fix, repeated client restarts no longer degrade the rate (verified in the campaign: three consecutive client restarts held 9.3 / 9.2 / 8.7 Hz, vs 2.6 / 2.1 / 2.5 Hz and falling before the patch).

## Note for the maintainer

With disconnects now actually shrinking the set, the `LockedSet` iteration race in the emit workers becomes reachable (it was masked by this leak). Companion fix: https://github.com/5G-ERA/era-5g-interface/pull/40 — they should land together, ideally the `era-5g-interface` one first.
